### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/backend/api/sessions.py
+++ b/backend/api/sessions.py
@@ -27,6 +27,7 @@ from backend.utils.cache import (
 )
 from backend.utils.logger import get_logger
 
+import traceback
 # Set up logging
 logger = get_logger(__name__)
 
@@ -654,8 +655,9 @@ async def stream_turn_response(session_id: str, request: SessionTurnRequest):
 
         except Exception as e:
             logger.error(f"✗ Streaming turn processing failed: {e}")
-            yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"
-
+            logger.error(traceback.format_exc())
+            # Yield only a generic error message to clients
+            yield f"data: {json.dumps({'type': 'error', 'message': 'An internal error has occurred'})}\n\n"
     return StreamingResponse(
         generate_stream(),
         media_type="text/plain",


### PR DESCRIPTION
Potential fix for [https://github.com/AB-Law/QuietStories/security/code-scanning/4](https://github.com/AB-Law/QuietStories/security/code-scanning/4)

To fix the issue, sanitize the error message sent to the client in the SSE response on exception. Instead of returning the full string representation of the exception (`str(e)`), log the exception details internally (using `logger.error` and/or traceback), but yield only a generic error message such as `"An internal error has occurred"` in the SSE response. To assist server-side debugging, log the full stack trace using the logging facility and Python's `traceback` module. No changes are required outside the relevant try/except block in the `generate_stream` function. You may need to import Python's `traceback` module if not already present.

Specifically:
- In backend/api/sessions.py, inside the except block starting at line 655, change the SSE yield to a generic message.
- Log the full stack trace server-side for diagnosis.
- Import the `traceback` module at the top if not present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
